### PR TITLE
Add error-handling and updated documentation.

### DIFF
--- a/genAristaMIBReport.py
+++ b/genAristaMIBReport.py
@@ -21,8 +21,9 @@
 ########################################
 # Dependencies
 # -----------
-# This requires BeautifulSoup and mibdump tool from http://snmplabs.com/pysmi/mibdump.html
-#
+# This requires BeautifulSoup and pysmi.
+#   pip install beautifulsoup
+#   pip install pysmi
 ########################################
 # Change log
 # ==========
@@ -42,6 +43,16 @@ import csv
 import argparse
 import sys
 
+# Check to make sure pysmi is Installed
+import imp
+try:
+    imp.find_module('pysmi')
+    found = True
+except ImportError:
+    found = False
+if found == False:
+    print 'Failed to load pysmi, please install from pip.'
+    exit()
 #######################################################
 # Global Variables
 #######################################################


### PR DESCRIPTION
Added doc to switch mibtool.py over to pysmi library which includes it.

Added some error checking to tell if pysmi is not installed, and exit function. Function appears to complete successfully without it unless you look higher in stdout and notice the errors. Beautifulsoup fails on script launch since it has a defined import - pysmi (mibtool.py) does not, this method makes it easier to tell at the beginning that there are additional libraries required.